### PR TITLE
Removed duplicate dependencies

### DIFF
--- a/deeplearning4j-core/pom.xml
+++ b/deeplearning4j-core/pom.xml
@@ -14,8 +14,6 @@
 
 	</properties>
 
-
-
 	<dependencies>
 
 		<dependency>
@@ -36,11 +34,6 @@
 			<artifactId>logback-core</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.1</version>
-		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -253,49 +253,7 @@
             </plugins>
 
         </pluginManagement>
-        <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.1</version>
-
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId></plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
-
-
-
-
-
 
     <dependencyManagement>
         <dependencies>
@@ -316,11 +274,6 @@
                 <artifactId>nd4j-jblas</artifactId>
                 <version>${nd4j.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Seeing the following warnings due to the duplicate dependences:

{Code}

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:deeplearning4j-core:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.commons:commons-lang3:jar -> version 3.1 vs 3.3.1 @ line 97, column 21
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:deeplearning4j-scaleout-akka:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:deeplearning4j-scaleout-api:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:deeplearning4j-nlp:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:deeplearning4j-scaleout-zookeeper:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:deeplearning4j-aws:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:cdh4:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:hadoop-yarn:pom:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:spark-cdh5:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.scala-tools:maven-scala-plugin is missing. @ line 33, column 22
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:spark-databricks:jar:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:spark:pom:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:deeplearning4j-scaleout:pom:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.deeplearning4j:deeplearning4j-parent:0.0.3.3.2.alpha1-SNAPSHOT, /Users/smarthi/opensourceprojects/java-deeplearning/pom.xml, line 275, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.deeplearning4j:deeplearning4j-parent:pom:0.0.3.3.2.alpha1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> duplicate declaration of version ${slf4j.version} @ line 335, column 25
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ line 281, column 21
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ line 236, column 25
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ line 275, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 

{Code}